### PR TITLE
Fix incorrect import in predictor.py

### DIFF
--- a/psyke/extraction/cart/predictor.py
+++ b/psyke/extraction/cart/predictor.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from typing import Union, Any
 import numpy as np
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor

--- a/psyke/extraction/cart/predictor.py
+++ b/psyke/extraction/cart/predictor.py
@@ -1,4 +1,8 @@
-from collections.abc import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    # Python 3.9 compatibility
+    from collections import Iterable
 from typing import Union, Any
 import numpy as np
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor


### PR DESCRIPTION
In Python 3.10, the `Iterable` abstract class has been removed from the `collections` module and has since been in `collections.abc` (see https://stackoverflow.com/a/72032154/4251579)